### PR TITLE
Update docstrings to reflect returned values

### DIFF
--- a/pygrype/grype.py
+++ b/pygrype/grype.py
@@ -39,7 +39,7 @@ class Grype:
         """Get the version of Grype.
 
         Returns:
-            Dict: A dictionary containing the version information.
+            GrypeVersion: An object representing the Grype Executable version information.
         """
         process = subprocess.run(
             args=[self.path, 'version', '--output', 'json'],
@@ -81,7 +81,7 @@ class Grype:
             show_supressed (bool, optional): Whether to show suppressed vulnerabilities. Defaults to False.
 
         Returns:
-            Dict: A dictionary containing the scan results.
+            Scan: A Scan class instance representing the scan results.
         """
         args = [self.path, target, '--output', 'json']
 


### PR DESCRIPTION
The docstrings for the `scan` and `version` methods were incorrectly reporting that they returned dicts, rather than instances of `Scan` and `GrypeVersion` dataclasses.

This PR updates those doctrings to more correctly reflect the types returned.